### PR TITLE
Add PowerShell script and module

### DIFF
--- a/PSModule/README.md
+++ b/PSModule/README.md
@@ -1,0 +1,7 @@
+# echochohoo PowerShell Module
+This is a module version of echochohoo. It contains a function called `Write-Echo` and its alias `echochohoo`.
+## Usage
+Copy the `echochohoo` folder into the `Modules` folder (maybe `$home\Documents\WindowsPowerShell\Modules` for Windows PowerShell, or `$home\Documents\PowerShell\Modules` (Windows) `~/.local/share/powershell/Modules` (Linux) for PowerShell Core). Add the following line to the `$Profile` file:
+``` powershell
+Import-Module echochohoo
+```

--- a/PSModule/echochohoo/echochohoo.psm1
+++ b/PSModule/echochohoo/echochohoo.psm1
@@ -1,0 +1,22 @@
+function Write-Echo {
+    param(
+        [Parameter(Mandatory = $False)][switch] $NoNewLine,
+        [Parameter(Mandatory = $True, valueFromPipeline = $true)][String] $value
+    )
+
+    for ($i = 0; $i -lt $value.Length; $i++) {
+        if ($NoNewLine) {
+            Write-Host $value.Substring($i) -NoNewline
+        }
+        else {
+            Write-Host $value.Substring($i)
+        }
+    }
+    if ($NoNewLine) {
+        Write-Host
+    }
+}
+
+New-Alias -Name echochohoo -Value Write-Echo
+
+Export-ModuleMember -Function Write-Echo -Alias echocohoo

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # echochohoo
 A command line utility. echochohoo "echo" == "echochohoo". 
 
-Works well in [`bash`](https://www.gnu.org/software/bash/) and [`zsh`](http://www.zsh.org). 
+Works well in [`bash`](https://www.gnu.org/software/bash/), [`zsh`](http://www.zsh.org) and [`PowerShell`](https://docs.microsoft.com/en-us/powershell/). 
 
 Doesn't work in `sh` and `csh`.
 
@@ -21,7 +21,18 @@ echochohoo
 ➜  echochohoo git:(master) ✗ zsh echochohoo 这是肥音你懂吗
 这是肥音你懂吗是肥音你懂吗肥音你懂吗音你懂吗你懂吗懂吗吗
 ```
+
+For PowerShell:
+``` powershell
+> .\echochohoo.ps1 echo
+echo
+cho
+ho
+o
+> .\echochohoo.ps1 echo -NoNewLine
+echochohoo
+```
 # TODO
 
-- [ ] Support Powershell
+- [x] Support Powershell and `-NoNewLine` option
 - [ ] Support `-n` and other options as `echo` does

--- a/echochohoo.ps1
+++ b/echochohoo.ps1
@@ -1,0 +1,16 @@
+param(
+    [Parameter(Mandatory = $False)][switch] $NoNewLine,
+    [Parameter(Mandatory = $True, valueFromPipeline = $true)][String] $value
+)
+
+for ($i = 0; $i -lt $value.Length; $i++) {
+    if ($NoNewLine) {
+        Write-Host $value.Substring($i) -NoNewline
+    }
+    else {
+        Write-Host $value.Substring($i)
+    }
+}
+if ($NoNewLine) {
+    Write-Host
+}


### PR DESCRIPTION
除了脚本还有一个模块，模块里是符合cmdlet命名法的Write-Echo和别名echochohoo，这样导入这个模块就不需要`.\`或者`./`了。